### PR TITLE
Add npm-script to start mongodb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ node_modules/
 !client/*
 !client/
 !notes.md
-server/config/
+data/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,12 +60,15 @@ The automatic compilation of the TypeScript files is tasked on `grunt`. The conf
 
 To start the project with the watchers run:
 ```
+npm run database
+```
+```
 npm run prod
 ```
 and
 ```
 grunt
 ```
-on 2 seperate terminals inside the project.
+on **3 seperate terminals** inside the project directory.
 
 *Note: Look up the difference between --save, --save-dev and --global options in npm to make sure any modules you include are imported correctly into the project.*

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To run, install node.js and run the following in the cloned directory:
 
 ```
 $ npm install
+$ npm run database
 $ npm run build
 $ npm run start
 ```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
     "dev": "ts-node ./server/server.ts",
+    "database": "mongod --dbpath=data/",
     "start": "nodemon ./server/server.js",
     "prod": "npm run build && npm run start"
   },


### PR DESCRIPTION
Add a script inside the package.json to start the MongoDB daemon. The
daemon listens by default in port 27017.