### PR TITLE
Interweave front-end and REST API sessions

### DIFF
--- a/client/pages/login.ejs
+++ b/client/pages/login.ejs
@@ -1,6 +1,3 @@
-
-
-
 <div id="login_modal" class="modal fade" role="dialog">
     <div class="modal-dialog">
         <div class="modal-content">
@@ -12,11 +9,11 @@
                 <form action="/login" method="POST">
                   <div class="form-group">
                     <label for="username" class="lead">Όνομα χρήστη</label>
-                    <input type="text" class="form-control lead" placeholder="π.χ. zonk" name="l_username" required>
+                    <input type="text" class="form-control lead" placeholder="π.χ. zonk" name="username" required>
                   </div>
                   <div class="form-group">
                     <label for="password " class="lead">Κωδικός πρόσβασης</label>
-                    <input type="text" class="form-control lead" placeholder="let it be the right one" name="l_password" required>
+                    <input type="password" class="form-control lead" placeholder="let it be the right one" name="password" required>
                   </div>
                   <button type="submit" class="btn btn-primary">Σύνδεση</button>
                 </form>

--- a/client/pages/sign_up.ejs
+++ b/client/pages/sign_up.ejs
@@ -9,15 +9,15 @@
                 <form action="/sign_up" method="POST">
                   <div class="form-group">
                     <label for="email" class="lead">Διεύθυνση ηλεκτρονικού ταχυδρομείου</label>
-                    <input type="email" class="form-control lead" placeholder="π.χ. zonk@zonkmail.znk" name="s_email" required>
+                    <input type="email" class="form-control lead" placeholder="π.χ. zonk@zonkmail.znk" name="email" required>
                   </div>
                   <div class="form-group">
                     <label for="Username" class="lead">Όνομα χρήστη</label>
-                    <input type="text" class="form-control lead" placeholder="π.χ. zonk" name="s_username" required>
+                    <input type="text" class="form-control lead" placeholder="π.χ. zonk" name="username" required>
                   </div>
                   <div class="form-group">
                     <label for="password" class="lead">Κωδικός πρόσβασης</label>
-                    <input type="text" class="form-control lead" placeholder="plz be complex" name="s_password" required>
+                    <input type="password" class="form-control lead" placeholder="plz be complex" name="password" required>
                   </div>
                   <button type="submit" class="btn btn-primary">Εγγραφή</button>
                 </form>

--- a/server/controllers/UserController.ts
+++ b/server/controllers/UserController.ts
@@ -38,7 +38,7 @@ export default class UserController {
             
             console.log(user[0]);
             
-            const auth_token = session_manager.NewSession(user[0]);
+            const auth_token:string = session_manager.NewSession(user[0]);
 
             res.status(200).send({token: auth_token});
         });

--- a/server/routes/routes.ts
+++ b/server/routes/routes.ts
@@ -21,10 +21,14 @@ export default function (
         console.log("Hit on /observatory/api");        
         res.status(400).send({ message: "Bad Request" });
     })
+
     .post('/login', (req: Request, res: Response) => {
         console.log("Hit on /observatory/api/login");
         const username = req.body.username;
         const password = req.body.password;
+
+        console.log(`Login: ${username} ${password}`);
+        
 
         if (username && password) {
             user_controller.loginUser(req, res);
@@ -52,7 +56,7 @@ export default function (
         const username = req.body.username;
         const password = req.body.password;
 
-        console.log(`${email} ${username} ${password}`);
+        console.log(`#Back# Signup: ${email} ${username} ${password}`);
 
         if (email && username && password) {
             user_controller.addNewUser(req, res);


### PR DESCRIPTION
GUI Signup/Login/Logout is now functional. Saves the X-OBSERVATORY-AUTH
token inside each session. Replace https.request() from https-npm with
request() from request-npm. Print various debugging messages with
front-end back-end distinction.